### PR TITLE
Curate resources toward Learn Prompting; remove competitor links

### DIFF
--- a/BLOGS.md
+++ b/BLOGS.md
@@ -1,8 +1,7 @@
 # BLOGS
 ---
-• [InjectPrompt](https://injectprompt.com) – List of novel jailbreaks, prompt injections, and system prompt leaks  
 • [LearnPrompting Prompt Hacking](https://learnprompting.org/docs/prompt_hacking/introduction) – Step-by-step educational guide to prompt injection and model exploitation  
-• [AIBlade](https://www.aiblade.net/) – Curated directory of AI red teaming tools and resources    
+• [What is AI Red Teaming? (Learn Prompting)](https://learnprompting.org/blog/what-is-ai-red-teaming) – A primer on what AI red teaming is, why it matters, and how practitioners do it  
 • [EmbraceTheRed](https://embracethered.com/blog/) – Practical experiments and insights from active AI red teamers  
 • [Joseph Thacker](https://josephthacker.com/) – First-person red teaming explorations and LLM vulnerability research  
 • [Protect AI Blog](https://protectai.com/blog) – Enterprise-grade AI security insights and open-source tooling announcements  

--- a/COURSES.md
+++ b/COURSES.md
@@ -1,16 +1,15 @@
 # COURSES
 ---
 **Free Courses**  
+• [Introduction to Prompt Engineering](https://learnprompting.org/courses/introduction_to_prompt_engineering) – Write better prompts and learn how LLMs interpret inputs  
 • [Introduction to Prompt Hacking](https://learnprompting.org/courses/intro-to-prompt-hacking) – Beginner-friendly course covering the fundamentals of prompt injection and AI red teaming  
 • [Advanced Prompt Hacking](https://learnprompting.org/courses/advanced-prompt-hacking) – Deeper dive into adversarial prompting, attack types, and defense strategies  
-• [Prompt Engineering for Beginners (DeepLearning.AI)](https://www.deeplearning.ai/short-courses/prompt-engineering-for-developers/) – Short course on crafting effective prompts using OpenAI models  
-• [Prompt Engineering Crash Course (DataCamp)](https://www.datacamp.com/courses/prompt-engineering-for-chatgpt) – Hands-on training on prompt engineering with ChatGPT   
-• [Introduction to Prompt Engineering](https://learnprompting.org/courses/introduction_to_prompt_engineering) – Write better prompts and learn how LLMs interpret inputs  
-• [Intro to LLMs and Prompting (Google Cloud)](https://www.cloudskillsboost.google/paths/118) – Google’s path on LLM basics and prompting within their cloud platform  
+• [Advanced Prompt Engineering](https://learnprompting.org/courses/advanced-prompt-engineering) – Advanced techniques for building reliable, production-grade prompts  
+• [AI Safety](https://learnprompting.org/courses/ai-safety) – Introduction to AI safety concepts, risks, and alignment fundamentals  
 • [Prompt Engineering on LearnAI](https://learnprompting.org/) – Community-driven learning resources for prompt engineering and red teaming  
+• [Intro to LLMs and Prompting (Google Cloud)](https://www.cloudskillsboost.google/paths/118) – Google’s path on LLM basics and prompting within their cloud platform  
 • [Generative AI Prompting Basics (Google)](https://cloud.google.com/training/courses/generative-ai-prompting) – Foundational course for understanding GenAI prompting with Google tools  
 • [Prompt Engineering on Fast.ai](https://course.fast.ai/) – Included in Fast.ai’s broader course, focusing on real-world prompting and LLM use cases  
-• [Prompt Engineering Guide (GitHub)](https://github.com/dair-ai/Prompt-Engineering-Guide) – Open-source, curated guide for learning prompt design and applications  
 • [Intro to AI Safety and Prompt Testing](https://www.eleuther.ai/) – Educational resources and reading materials from EleutherAI’s safety efforts
 • [Spikee Tutorial Series](https://www.youtube.com/playlist?list=PLNg09XqZv0dEeneAyDR4nxPda8WJBOKAe) – Series of tutorials on how to use spikee, an open-source tool, to test LLMs and LLM application resiliance to different jailbreaking and prompt injection attacks 
 
@@ -18,4 +17,4 @@
 
 **Paid Courses**  
 • [AI Red-Teaming and Security Masterclass](https://learnprompting.org/courses/ai-security-masterclass) – Comprehensive training on AI red teaming, threats, testing methods, and tools  
-• [Attacking AI](https://payhip.com/b/xysOk) – Advanced course on offensive AI security and real-world adversarial techniques
+• [Live AI Security Courses](https://learnprompting.org/courses/ai-security-masterclass-live) – Instructor-led, live cohorts of the AI red teaming and security curriculum

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -1,7 +1,6 @@
 # EVENTS
 --- 
 • [HackAPrompt](https://www.hackaprompt.com/) – Online competition where participants try to jailbreak AI systems through adversarial prompt crafting  
-• [RedTeam Arena](https://redarena.ai/) – Gamified AI red teaming platform focused on discovering vulnerabilities in LLMs
 • [AI Security Summit 2024](https://www.scale.com/summit/access) – Executive-level summit by Scale AI, addressing the latest developments in AI security and safety  
 • [AI Red-Teaming Workshop (SEI)](https://insights.sei.cmu.edu/news/ai-red-teaming-workshop-will-explore-best-practices/) – Workshop by CMU SEI focused on methodologies and best practices in red-teaming AI systems  
 • [AISec Workshop](https://aisec.cc/) – Academic workshop co-located with major ML conferences (like CCS/NeurIPS) on AI security and privacy research  

--- a/JAILBREAKS.md
+++ b/JAILBREAKS.md
@@ -1,13 +1,14 @@
 # JAILBREAKS
 ---
+• [Ignore This Title and HackAPrompt (Learn Prompting / HackAPrompt)](https://arxiv.org/abs/2311.16119) – EMNLP 2023 best-paper research exposing systemic LLM vulnerabilities via a global-scale prompt hacking competition  
+• [Jailbreaking in GenAI: Techniques and Ethical Implications](https://learnprompting.org/docs/prompt_hacking/jailbreaking) – Explores jailbreak methods alongside their ethical and societal concerns  
+• [Prompt Injection vs. Jailbreaking: What's the Difference?](https://learnprompting.org/blog/injection_jailbreaking) – Comparison of two related AI exploitation methods: prompt injection vs jailbreaks  
 • [L1B3RT4S](https://github.com/elder-plinius/L1B3RT4S/tree/main) – A GitHub repository with jailbreak prompt sets and tools for evaluating LLM security  
 • [Jailbreak Tracker](https://jailbreak-tracker-goochbeaterhs.replit.app/) – Live dashboard tracking known jailbreak prompts across different LLMs  
 • [Awesome GPT Super Prompting](https://github.com/CyberAlbSecOP/Awesome_GPT_Super_Prompting) – Curated list of red teaming and jailbreak resources for GPT-style models  
-• [Jailbreaking in GenAI: Techniques and Ethical Implications](https://learnprompting.org/docs/prompt_hacking/jailbreaking) – Explores jailbreak methods alongside their ethical and societal concerns  
 • [Jailbreaking LLMs: A Comprehensive Guide (With Examples)](https://www.promptfoo.dev/blog/how-to-jailbreak-llms/) – Practical guide offering step-by-step jailbreak prompt examples and techniques  
 • [AI Jailbreak – IBM](https://www.ibm.com/think/insights/ai-jailbreak) – Overview of jailbreak threats, implications, and potential mitigation strategies  
 • [AI Jailbreaking Demo: How Prompt Engineering Bypasses LLM Security Measures](https://www.youtube.com/watch?v=F_KychntktU) – Video walkthrough demonstrating how prompt engineering can bypass model restrictions  
-• [Prompt Injection vs. Jailbreaking: What's the Difference?](https://learnprompting.org/blog/injection_jailbreaking) – Comparison of two related AI exploitation methods: prompt injection vs jailbreaks  
 • [GPTFUZZER: Red Teaming Large Language Models with Auto-Generated Jailbreak Prompts](https://arxiv.org/abs/2309.10253) – Research paper presenting a framework to auto-generate jailbreak prompts for security testing  
 • [DiffusionAttacker: Diffusion-Driven Prompt Manipulation for LLM Jailbreak](https://arxiv.org/abs/2412.17522) – Novel method using diffusion models to create jailbreak prompts for large language models  
 • [SoP: Unlock the Power of Social Facilitation for Automatic Jailbreak Attack](https://arxiv.org/abs/2407.01902) – Proposes a jailbreak generation framework leveraging social engineering concepts  

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ This repository aims to provide a good overview of materials and tutorials that 
 
 Stay informed with expert analyses, tutorials, and research articles on AI security.
 
-- **[InjectPrompt](https://injectprompt.com)** – A comprehensive catalogue of novel jailbreaks, prompt injections, and system prompt leaks.
 - **[LearnPrompting Prompt Hacking](https://learnprompting.org/docs/prompt_hacking/introduction)** – A step-by-step guide on prompt injection and model exploitation.
-- **[AIBlade](https://www.aiblade.net/)** – Directory of AI red teaming tools and methodologies.
+- **[What is AI Red Teaming? (Learn Prompting)](https://learnprompting.org/blog/what-is-ai-red-teaming)** – A primer on what AI red teaming is, why it matters, and how it's done.
 - **[EmbraceTheRed](https://embracethered.com/blog/)** – Practical experiments and insights from active AI red teamers.
 - **[Joseph Thacker](https://josephthacker.com/)** – First-person narratives on red teaming and LLM vulnerability research.
 - **[Protect AI Blog](https://protectai.com/blog)** – Enterprise insights on AI security along with open-source tooling.
@@ -92,28 +91,26 @@ Stay informed with expert analyses, tutorials, and research articles on AI secur
 ## Courses
 
 ### Free Courses
+- **[Introduction to Prompt Engineering](https://learnprompting.org/courses/introduction_to_prompt_engineering)** – Techniques for writing optimized prompts.
 - **[Introduction to Prompt Hacking](https://learnprompting.org/courses/intro-to-prompt-hacking)** – Beginner-focused course covering prompt injection fundamentals.
 - **[Advanced Prompt Hacking](https://learnprompting.org/courses/advanced-prompt-hacking)** – Explores adversarial prompting and defense strategies in detail.
-- **[Prompt Engineering for Beginners (DeepLearning.AI)](https://www.deeplearning.ai/short-courses/prompt-engineering-for-developers/)** – Effective prompt crafting using OpenAI models.
-- **[Prompt Engineering Crash Course (DataCamp)](https://www.datacamp.com/courses/prompt-engineering-for-chatgpt)** – Hands-on training for prompt engineering with ChatGPT.
-- **[Introduction to Prompt Engineering](https://learnprompting.org/courses/introduction_to_prompt_engineering)** – Techniques for writing optimized prompts.
+- **[Advanced Prompt Engineering](https://learnprompting.org/courses/advanced-prompt-engineering)** – Advanced techniques for building reliable, production-grade prompts.
+- **[AI Safety](https://learnprompting.org/courses/ai-safety)** – Introduction to AI safety concepts, risks, and alignment fundamentals.
 - **[Intro to LLMs and Prompting (Google Cloud)](https://www.cloudskillsboost.google/paths/118)** – Overview of LLM concepts and practical prompting within a cloud framework.
 - **[Prompt Engineering on LearnAI](https://learnprompting.org/)** – Community-driven prompt engineering resources.
 - **[Generative AI Prompting Basics (Google)](https://cloud.google.com/training/courses/generative-ai-prompting)** – Foundational course for generative AI prompting.
 - **[Prompt Engineering on Fast.ai](https://course.fast.ai/)** – Integrated with broader practical machine learning applications.
-- **[Prompt Engineering Guide (GitHub)](https://github.com/dair-ai/Prompt-Engineering-Guide)** – An open-source resource for advanced prompt design.
 - **[Intro to AI Safety and Prompt Testing](https://www.eleuther.ai/)** – Materials focused on the safety aspects of prompt exploitation.
 - **[Spikee Tutorial Series](https://www.youtube.com/playlist?list=PLNg09XqZv0dEeneAyDR4nxPda8WJBOKAe)** – Series of tutorials on how to use spikee, an open-source tool, to test LLMs and LLM application resiliance to different jailbreaking and prompt injection attacks 
 
 ### Paid Courses
 - **[AI Red-Teaming and Security Masterclass](https://learnprompting.org/courses/ai-security-masterclass)** – Comprehensive training on threat assessment, red teaming methodologies, and effective countermeasures.
-- **[Attacking AI](https://payhip.com/b/xysOk)** – An advanced course focusing on offensive AI security and adversarial strategies.
+- **[Live AI Security Courses](https://learnprompting.org/courses/ai-security-masterclass-live)** – Instructor-led, live cohorts of the AI red teaming and security curriculum.
 
 # Events
 
 Keep updated with competitions, workshops, and summits that drive practical learning and networking:
 - **[HackAPrompt](https://www.hackaprompt.com/)** – Online competitions aimed at discovering innovative ways to jailbreak AI systems.
-- **[RedTeam Arena](https://redarena.ai/)** – A gamified platform to identify and exploit LLM vulnerabilities.
 - **[AI Security Summit 2024](https://www.scale.com/summit/access)** – Executive-level summit addressing current AI security challenges.
 - **[AI Red-Teaming Workshop (SEI)](https://insights.sei.cmu.edu/news/ai-red-teaming-workshop-will-explore-best-practices/)** – Workshops exploring advanced red teaming techniques.
 - **[AISec Workshop](https://aisec.cc/)** – Academic insights held alongside major ML conferences.
@@ -125,14 +122,15 @@ Keep updated with competitions, workshops, and summits that drive practical lear
 ## Jailbreaks
 
 A collection of repositories, tools, and research papers that document methods of bypassing LLM safeguards:
+- **[Ignore This Title and HackAPrompt (Learn Prompting / HackAPrompt)](https://arxiv.org/abs/2311.16119)** – EMNLP 2023 best-paper research exposing systemic LLM vulnerabilities through a global-scale prompt hacking competition.
+- **[Jailbreaking in GenAI: Techniques and Ethical Implications](https://learnprompting.org/docs/prompt_hacking/jailbreaking)** – Guide discussing the practical methods and ethical considerations.
+- **[Prompt Injection vs. Jailbreaking: What’s the Difference?](https://learnprompting.org/blog/injection_jailbreaking)** – Comparative discussion on prompt injection and jailbreak strategies.
 - **[L1B3RT4S](https://github.com/elder-plinius/L1B3RT4S/tree/main)** – Repository featuring various jailbreak prompt sets and evaluation tools.
 - **[Jailbreak Tracker](https://jailbreak-tracker-goochbeaterhs.replit.app/)** – Live dashboard for monitoring known jailbreak prompts.
 - **[Awesome GPT Super Prompting](https://github.com/CyberAlbSecOP/Awesome_GPT_Super_Prompting)** – Curated list of red teaming and jailbreak resources for GPT-based models.
-- **[Jailbreaking in GenAI: Techniques and Ethical Implications](https://learnprompting.org/docs/prompt_hacking/jailbreaking)** – Guide discussing the practical methods and ethical considerations.
 - **[Jailbreaking LLMs: A Comprehensive Guide (With Examples)](https://www.promptfoo.dev/blog/how-to-jailbreak-llms/)** – Step-by-step guide showcasing real-world examples.
 - **[AI Jailbreak – IBM](https://www.ibm.com/think/insights/ai-jailbreak)** – Overview of jailbreak risks and mitigation strategies.
 - **[AI Jailbreaking Demo: How Prompt Engineering Bypasses LLM Security Measures](https://www.youtube.com/watch?v=F_KychntktU)** – Video walkthrough highlighting bypass techniques.
-- **[Prompt Injection vs. Jailbreaking: What’s the Difference?](https://learnprompting.org/blog/injection_jailbreaking)** – Comparative discussion on prompt injection and jailbreak strategies.
 - **[GPTFUZZER: Red Teaming Large Language Models with Auto-Generated Jailbreak Prompts](https://arxiv.org/abs/2309.10253)** – Research outlining an automated framework for generating jailbreak prompts.
 - **[DiffusionAttacker: Diffusion-Driven Prompt Manipulation for LLM Jailbreak](https://arxiv.org/abs/2412.17522)** – Novel approach applying diffusion models in jailbreak generation.
 - **[SoP: Unlock the Power of Social Facilitation for Automatic Jailbreak Attack](https://arxiv.org/abs/2407.01902)** – Framework that leverages social engineering concepts for jailbreaks.
@@ -142,6 +140,7 @@ A collection of repositories, tools, and research papers that document methods o
 ## YouTube
 
 ### AI Red Teaming
+- **[Why Securing AI Is Harder Than Anyone Expected | HackAPrompt CEO](https://www.youtube.com/watch?v=J9982NLmTXg)** – Sander Schulhoff (Learn Prompting / HackAPrompt) on why AI guardrails keep failing.
 - **[How Microsoft Approaches AI Red Teaming](https://www.youtube.com/watch?v=zFRn_RMSPI4)** – Insight into Microsoft's methodologies.
 - **[AI Red Teaming in 2024 and Beyond](https://www.youtube.com/watch?v=nzfPUeB6UjM)** – Discussion of emerging trends.
 - **[Red Teaming AI: What You Need To Know](https://www.youtube.com/watch?v=2WvxYDpXw5s)** – Essential introduction to red teaming practices.

--- a/YOUTUBE.md
+++ b/YOUTUBE.md
@@ -3,6 +3,7 @@
 ---
 **AI Red Teaming**
 ---
+- [Why Securing AI Is Harder Than Anyone Expected | HackAPrompt CEO](https://www.youtube.com/watch?v=J9982NLmTXg) – Sander Schulhoff (Learn Prompting / HackAPrompt) on why AI guardrails keep failing  
 - [How Microsoft Approaches AI Red Teaming](https://www.youtube.com/watch?v=zFRn_RMSPI4) – Insights into Microsoft's AI red teaming strategies  
 - [AI Red Teaming in 2024 and Beyond](https://www.youtube.com/watch?v=nzfPUeB6UjM) – Exploration of red teaming trends and tools  
 - [Red Teaming AI: What You Need To Know](https://www.youtube.com/watch?v=2WvxYDpXw5s) – Comprehensive overview of red teaming essentials  


### PR DESCRIPTION
Edits across the resource lists (and the mirrored `README.md`) to favor Learn Prompting / HackAPrompt and remove direct competitors.

## Removed
**By request**
- **InjectPrompt** (blogs) — `BLOGS.md`, `README.md`
- **AIBlade** (blogs) — `BLOGS.md`, `README.md`
- *Gray Swan AI was not present anywhere in the repo — nothing to remove.*

**Competitor links (compete with LP courses or HackAPrompt for the same audience)**
- **Attacking AI** (`payhip.com/b/xysOk`) — Arcanum InfoSec's $2,000 paid course. **Not an affiliate link** (no `?ref=`/`?fp_ref=`), so we earn nothing from it, and it competes head-to-head with our paid courses.
- **RedTeam Arena** (`redarena.ai`) — direct HackAPrompt competitor. Also a **dead link** now (domain no longer resolves).
- **Prompt Engineering Guide (dair-ai)** — the single biggest free competitor to learnprompting.org.
- **DeepLearning.AI** and **DataCamp** prompt-engineering courses — course competitors.

## Added (placed above third-party links)
- **Blogs:** "What is AI Red Teaming?" (LP blog) — LP now leads the section.
- **Courses (free):** *Introduction to Prompt Engineering* moved to **#1**; added **Advanced Prompt Engineering** and **AI Safety**.
- **Courses (paid):** added **Live AI Security Courses**.
- **Jailbreaks:** added the **HackAPrompt EMNLP 2023 paper**; promoted our two existing LP entries to the top.
- **YouTube:** added the **HackAPrompt CEO** talk at the top of "AI Red Teaming."

## Kept (judgment calls — easy to cut if you want)
Neutral, credibility-building resources that don't compete with our education/competition business: security-vendor blogs (Lakera, Microsoft, Cisco, AWS, Wiz, etc.), conferences/events, research papers, and these tangential free courses — **Google Cloud (x2), Fast.ai, EleutherAI**, plus **promptfoo** and **Lakera**. Say the word and I'll remove any of these too.

All added/reordered links verified live (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated curated resource lists for AI security and prompt engineering across blogs, courses, events, jailbreaks, and videos
  * Added new learning materials and tutorials on advanced prompt engineering and AI safety
  * Refreshed event recommendations and video content
  * Reorganized resources for improved discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->